### PR TITLE
update status of some testcases

### DIFF
--- a/testcases/linux_libc_test/riscv64_bare.txt
+++ b/testcases/linux_libc_test/riscv64_bare.txt
@@ -88,8 +88,8 @@
 /libc-test/functional/setjmp.exe                                                OK
 /libc-test/functional/snprintf-static.exe                                       OK
 /libc-test/functional/snprintf.exe                                              OK
-/libc-test/functional/socket-static.exe                                         FAILED
-/libc-test/functional/socket.exe                                                FAILED
+/libc-test/functional/socket-static.exe                                         OK
+/libc-test/functional/socket.exe                                                OK
 /libc-test/functional/spawn-static.exe                                          TIMEOUT
 /libc-test/functional/spawn.exe                                                 TIMEOUT
 /libc-test/functional/sscanf-static.exe                                         OK
@@ -146,8 +146,8 @@
 /libc-test/functional/udiv.exe                                                  OK
 /libc-test/functional/ungetc-static.exe                                         OK
 /libc-test/functional/ungetc.exe                                                OK
-/libc-test/functional/utime-static.exe                                          FAILED
-/libc-test/functional/utime.exe                                                 FAILED
+/libc-test/functional/utime-static.exe                                          OK
+/libc-test/functional/utime.exe                                                 OK
 /libc-test/functional/vfork-static.exe                                          FAILED
 /libc-test/functional/vfork.exe                                                 FAILED
 /libc-test/functional/wcsstr-static.exe                                         OK
@@ -496,8 +496,8 @@
 /oscomp/dup                                                                     OK
 /oscomp/dup2                                                                    OK
 /oscomp/execve                                                                  OK
-/oscomp/exit                                                                    FAILED
-/oscomp/fork                                                                    FAILED
+/oscomp/exit                                                                    OK
+/oscomp/fork                                                                    OK
 /oscomp/fstat                                                                   FAILED
 /oscomp/getcwd                                                                  OK
 /oscomp/getdents                                                                OK
@@ -518,7 +518,7 @@
 /oscomp/umount                                                                  OK
 /oscomp/uname                                                                   OK
 /oscomp/unlink                                                                  OK
-/oscomp/wait                                                                    FAILED
+/oscomp/wait                                                                    OK
 /oscomp/waitpid                                                                 FAILED
 /oscomp/write                                                                   OK
 /oscomp/yield                                                                   OK

--- a/testcases/linux_libc_test/x86_64_bare.txt
+++ b/testcases/linux_libc_test/x86_64_bare.txt
@@ -73,8 +73,8 @@
 /libc-test/src/functional/setjmp.exe                                            OK
 /libc-test/src/functional/snprintf-static.exe                                   OK
 /libc-test/src/functional/snprintf.exe                                          OK
-/libc-test/src/functional/socket-static.exe                                     FAILED
-/libc-test/src/functional/socket.exe                                            FAILED
+/libc-test/src/functional/socket-static.exe                                     OK
+/libc-test/src/functional/socket.exe                                            OK
 /libc-test/src/functional/spawn-static.exe                                      FAILED
 /libc-test/src/functional/spawn.exe                                             FAILED
 /libc-test/src/functional/sscanf-static.exe                                     OK
@@ -345,8 +345,8 @@
 /libc-test/src/regression/dn_expand-empty.exe                                   OK
 /libc-test/src/regression/dn_expand-ptr-0-static.exe                            OK
 /libc-test/src/regression/dn_expand-ptr-0.exe                                   OK
-/libc-test/src/regression/execle-env-static.exe                                 TIMEOUT
-/libc-test/src/regression/execle-env.exe                                        TIMEOUT
+/libc-test/src/regression/execle-env-static.exe                                 OK
+/libc-test/src/regression/execle-env.exe                                        OK
 /libc-test/src/regression/fflush-exit-static.exe                                OK
 /libc-test/src/regression/fflush-exit.exe                                       OK
 /libc-test/src/regression/fgets-eof-static.exe                                  OK

--- a/testcases/linux_libc_test/x86_64_libos.txt
+++ b/testcases/linux_libc_test/x86_64_libos.txt
@@ -36,7 +36,7 @@
 /libc-test/src/functional/sem_open.exe                                          FAILED
 /libc-test/src/functional/setjmp.exe                                            OK
 /libc-test/src/functional/snprintf.exe                                          OK
-/libc-test/src/functional/socket.exe                                            FAILED
+/libc-test/src/functional/socket.exe                                            OK
 /libc-test/src/functional/spawn.exe                                             FAILED
 /libc-test/src/functional/sscanf.exe                                            OK
 /libc-test/src/functional/sscanf_long.exe                                       OK
@@ -279,8 +279,8 @@
 /libc-test/src/regression/flockfile-list.exe                                    OK
 /libc-test/src/regression/fpclassify-invalid-ld80.exe                           OK
 /libc-test/src/regression/ftello-unflushed-append.exe                           OK
-/libc-test/src/regression/getpwnam_r-crash.exe                                  FAILED
-/libc-test/src/regression/getpwnam_r-errno.exe                                  FAILED
+/libc-test/src/regression/getpwnam_r-crash.exe                                  OK
+/libc-test/src/regression/getpwnam_r-errno.exe                                  OK
 /libc-test/src/regression/iconv-roundtrips.exe                                  OK
 /libc-test/src/regression/inet_ntop-v4mapped.exe                                OK
 /libc-test/src/regression/inet_pton-empty-last-field.exe                        OK

--- a/testcases/zircon_core_test/x86_64_bare.txt
+++ b/testcases/zircon_core_test/x86_64_bare.txt
@@ -489,7 +489,7 @@ ProfileTest.CreateProfileWithNoProfileInfoIsInvalidArgs                         
 ProfileTest.CreateProfileWithNullProfileIsInvalidArgs                                               FAILED
 ProgressiveCloneDiscardTests.ProgressiveCloneClose                                                  OK
 ProgressiveCloneDiscardTests.ProgressiveCloneTruncate                                               OK
-Pthread.Basic                                                                                       OK
+Pthread.Basic                                                                                       TIMEOUT
 Pthread.BigStackSize                                                                                OK
 Pthread.GetstackMainThread                                                                          OK
 Pthread.GetstackOtherThread                                                                         OK

--- a/testcases/zircon_core_test/x86_64_libos.txt
+++ b/testcases/zircon_core_test/x86_64_libos.txt
@@ -22,7 +22,7 @@ C11ThreadTest.CreateAndVerifyThreadHandle                                       
 C11ThreadTest.DetachedThreadKeepsRunning                                                            OK
 C11ThreadTest.LongNameSucceeds                                                                      OK
 C11ThreadTest.NullNameThreadShouldSucceed                                                           OK
-C11ThreadTest.SelfDetachAndFree                                                                     OK
+C11ThreadTest.SelfDetachAndFree                                                                     PARTIAL
 C11ThreadTest.ThreadLocalErrno                                                                      OK
 ChannelInternalTest.CallFinishWithoutPreviouslyCallingCallReturnsBadState                           FAILED
 ChannelInternalTest.TransferChannelWithPendingCallInSourceProcess                                   OK


### PR DESCRIPTION
  change some status from FAILED or TIMEOUT to OK.
  change Pthread.Basic form OK to TIMEOUT, because its running time is more long, easy to timeout.
  change C11ThreadTest.SelfDetachAndFree from OK to PARTIAL, because 3 FAILED was observed in 100 cycles.