### PR TITLE
Mark pthread_robust as FAILED

### DIFF
--- a/testcases/linux_libc_test/riscv64_bare.txt
+++ b/testcases/linux_libc_test/riscv64_bare.txt
@@ -49,8 +49,8 @@
 /libc-test/src/functional/pthread_mutex.exe                                         TIMEOUT
 /libc-test/src/functional/pthread_mutex_pi-static.exe                               TIMEOUT
 /libc-test/src/functional/pthread_mutex_pi.exe                                      TIMEOUT
-/libc-test/src/functional/pthread_robust-static.exe                                 OK
-/libc-test/src/functional/pthread_robust.exe                                        PARTIAL
+/libc-test/src/functional/pthread_robust-static.exe                                 FAILED
+/libc-test/src/functional/pthread_robust.exe                                        FAILED
 /libc-test/src/functional/pthread_tsd-static.exe                                    OK
 /libc-test/src/functional/pthread_tsd.exe                                           OK
 /libc-test/src/functional/qsort-static.exe                                          OK


### PR DESCRIPTION
I am trying to fix sleep time problem in zCore, but after doing that, I find that the pthread_robust test case fails. This test case has been marked OK in the commit "some bugs of pthread are fixed, so change the status of testcases to OK" (not by us) , which is not our intention when fixing the pthread. It was just a coincidence that it passed if sleep time was wrong.